### PR TITLE
sorts map display by city instead of by "name"

### DIFF
--- a/views.py
+++ b/views.py
@@ -4,7 +4,7 @@ from django.template import RequestContext
 from core.models import Place
 
 def map(request):
-    places = Place.objects.all()
+    places = Place.objects.all().order_by("city")
 
     page_title = "Newspapers by City"
     return render(request, 'map.html', locals())


### PR DESCRIPTION
By default the places return ordered by "name" but that means that displaying them by city is all kinds of interesting orders to the reader.  Specifying a sort in this plugin (although we could also consider changing the meta definition in the openoni models file if we always want places returned by city).

Closes https://github.com/CDRH/open-oni_nebraska_theme/issues/75